### PR TITLE
Stackless

### DIFF
--- a/formula/stackless-2.6.5
+++ b/formula/stackless-2.6.5
@@ -9,7 +9,7 @@ echo "Building SQLite..."
 echo "Building Python..."
 SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-265-export.tar.bz2'
 curl -L $SOURCE_TARBALL | tar xj
-mv stackless-265-export src
+mv python-2.6.5-stackless src
 cd src
 
 ./configure --prefix=$OUT_PREFIX

--- a/formula/stackless-2.6.5
+++ b/formula/stackless-2.6.5
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Options: <output-dir>
+
+OUT_PREFIX=$1
+
+echo "Building SQLite..."
+./parts/sqlite $OUT_PREFIX
+
+echo "Building Python..."
+SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-265-export.tar.bz2'
+curl -L $SOURCE_TARBALL | tar xj
+mv stackless-265-export src
+cd src
+
+./configure --prefix=$OUT_PREFIX
+make
+make install
+
+cd ..
+rm -fr src

--- a/formula/stackless-2.7.6
+++ b/formula/stackless-2.7.6
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Options: <output-dir>
+
+OUT_PREFIX=$1
+
+echo "Building SQLite..."
+./parts/sqlite $OUT_PREFIX
+
+echo "Building Python..."
+SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-276r3-export.tar.bz2'
+curl -L $SOURCE_TARBALL | tar xj
+mv stackless-276r3-export src
+cd src
+
+./configure --prefix=$OUT_PREFIX
+make
+make install
+
+cd ..
+rm -fr src

--- a/formula/stackless-3.1.3
+++ b/formula/stackless-3.1.3
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Options: <output-dir>
+
+OUT_PREFIX=$1
+
+echo "Building SQLite..."
+./parts/sqlite $OUT_PREFIX
+
+echo "Building Python..."
+SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-313-export.tar.bz2'
+curl -L $SOURCE_TARBALL | tar xj
+mv stackless-313-export src
+cd src
+
+./configure --prefix=$OUT_PREFIX
+make
+make install
+
+cd ..
+rm -fr src

--- a/formula/stackless-3.1.3
+++ b/formula/stackless-3.1.3
@@ -9,7 +9,7 @@ echo "Building SQLite..."
 echo "Building Python..."
 SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-313-export.tar.bz2'
 curl -L $SOURCE_TARBALL | tar xj
-mv stackless-313-export src
+mv python-3.1.3-stackless src
 cd src
 
 ./configure --prefix=$OUT_PREFIX

--- a/formula/stackless-3.2.5
+++ b/formula/stackless-3.2.5
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Options: <output-dir>
+
+OUT_PREFIX=$1
+
+echo "Building SQLite..."
+./parts/sqlite $OUT_PREFIX
+
+echo "Building Python..."
+SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-325-export.tar.bz2'
+curl -L $SOURCE_TARBALL | tar xj
+mv stackless-325-export src
+cd src
+
+./configure --prefix=$OUT_PREFIX
+make
+make install
+
+cd ..
+rm -fr src

--- a/formula/stackless-3.3.5
+++ b/formula/stackless-3.3.5
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Options: <output-dir>
+
+OUT_PREFIX=$1
+
+echo "Building SQLite..."
+./parts/sqlite $OUT_PREFIX
+
+echo "Building Python..."
+SOURCE_TARBALL='http://www.stackless.com/binaries/stackless-335-export.tar.bz2'
+curl -L $SOURCE_TARBALL | tar xj
+mv stackless-335-export src
+cd src
+
+./configure --prefix=$OUT_PREFIX
+make
+make install
+
+cd ..
+rm -fr src


### PR DESCRIPTION
Adds formula for Stackless Python (2.6.5, 2.7.6, 3.1.3, 3.2.5, 3.3.5).

The builds work, and the Pythons appear to work correctly on the platform -- tested manually because I don't have write perms for the official bucket.
