### PR TITLE
Update README.rst from Python 3.3 to Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Versions
 Official support for:
 
 - Latest CPython 2.7
-- Latest CPython 3.3
+- Latest CPython 3.4
 
 See also, `full list <https://github.com/kennethreitz/python-versions/tree/master/formula>`_.
 


### PR DESCRIPTION
There is official support for Python 3.4 unless I am mistaken.
